### PR TITLE
Updates to page for 20.10 release

### DIFF
--- a/components/download-info.vue
+++ b/components/download-info.vue
@@ -86,9 +86,6 @@
         <dt>Requirements:</dt>
         <dd>2 GB RAM, 16 GB storage, 64-bit processor</dd>
 
-        <dt>Recommended:</dt>
-        <dd>4 GB RAM, 16 GB storage, 64-bit processor</dd>
-
         <dt>Filesize:</dt>
         <dd>{{ intelSize }} GB, {{ nvidiaSize }} GB (NVIDIA)</dd>
 

--- a/components/download-info.vue
+++ b/components/download-info.vue
@@ -213,6 +213,11 @@
     margin: 1rem auto;
     max-width: 40ch;
     text-align: center;
+    font-size: 1rem;
+  }
+
+  dl {
+    font-size: 1rem;
   }
 
   dt {

--- a/components/download-info.vue
+++ b/components/download-info.vue
@@ -29,14 +29,31 @@
     </template>
 
     <template v-else>
-      <sys-header-2>
-        <template v-if="isLts">
-          Download {{ version }} LTS
-        </template>
-        <template v-else>
-          Download Latest {{ version }}
-        </template>
-      </sys-header-2>
+      <div
+        v-if="canSwitchRelease"
+        class="tab"
+      >
+        <div
+          :class="(!isLts) ? 'selected' : ''"
+          @click="toggle"
+        >
+          POP!_OS 20.10
+        </div>
+        <div
+          :class="(isLts) ? 'selected' : ''"
+          @click="toggle"
+        >
+          POP!_OS 20.04 LTS
+        </div>
+      </div>
+
+      <sys-paragraph-1 class="disclaimer">
+        If you have NVIDIA graphics, download the ISO with the proprietary
+        NVIDIA driver preinstalled.
+      </sys-paragraph-1>
+      <sys-paragraph-1 class="disclaimer">
+        Disable Secure Boot in your BIOS to install Pop!_OS.
+      </sys-paragraph-1>
 
       <div class="buttons">
         <sys-form-button
@@ -48,7 +65,7 @@
           :href="intelUrl"
           @click="$ga.event('download', 'download', 'intel', intelUrl)"
         >
-          Download
+          Download {{ version }}{{ (isLts) ? ' LTS' : '' }}
         </sys-form-button>
 
         <sys-form-button
@@ -60,17 +77,10 @@
           :href="nvidiaUrl"
           @click="$ga.event('download', 'download', 'nvidia', nvidiaUrl)"
         >
-          Download (nVidia)
+          Download {{ version }}{{ (isLts) ? ' LTS' : '' }} (nVidia)
         </sys-form-button>
       </div>
 
-      <sys-paragraph-1 class="disclaimer">
-        If you have NVIDIA graphics, download the ISO with the proprietary
-        NVIDIA driver preinstalled.
-      </sys-paragraph-1>
-      <sys-paragraph-1 class="disclaimer">
-        Disable Secure Boot in your BIOS to install Pop!_OS.
-      </sys-paragraph-1>
       <sys-paragraph-1 tag="dl">
         <dt>Requirements:</dt>
         <dd>2 GB RAM, 16 GB storage, 64-bit processor</dd>
@@ -100,24 +110,6 @@
           Learn how to create installation media.
         </a>
       </p>
-
-      <div class="foot">
-        <sys-form-button
-          v-if="canSwitchRelease"
-          color="primary"
-          ghost
-          rel="noopener"
-          target="_blank"
-          @click.prevent="toggle"
-        >
-          <template v-if="isLts">
-            Download latest {{ alternativeVersion }}
-          </template>
-          <template v-else>
-            Download {{ alternativeVersion }} LTS
-          </template>
-        </sys-form-button>
-      </div>
     </template>
   </div>
 </template>
@@ -126,7 +118,7 @@
   .container {
     border-radius: 3px;
     border: 1px solid transparent;
-    padding: 1rem;
+    padding: 3rem 1rem;
     position: relative;
   }
 
@@ -160,16 +152,37 @@
     background-color: rgba(0, 0, 0, 0.2);
   }
 
-  h2 {
+  .tab {
+    font-family: var(--font-family-slab);
+    font-size: 1.2rem;
+    font-weight: 700;
+    max-width: 40ch;
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+  }
+
+  .tab > div {
+    border: 1px solid #574F4A;
+    color: #574F4A;
+    width: 50%;
     text-align: center;
+    padding: .25em;
+    cursor: pointer;
+  }
+
+  .tab > div.selected {
+    background-color: #FFAD00;
+    color: #fff;
   }
 
   .buttons {
     align-content: center;
-    align-items: center;
+    align-items: stretch;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
+    flex-direction: column;
     margin: 0 -0.5rem;
   }
 
@@ -182,14 +195,8 @@
 
   .disclaimer {
     margin: 2rem auto 2rem;
-    max-width: 60ch;
+    max-width: 40ch;
     text-align: center;
-  }
-
-  .foot {
-    display: flex;
-    flex-direction: column;
-    margin: -0.5rem 0;
   }
 
   dt {
@@ -229,14 +236,6 @@
 
   .sha div {
     margin: 0.2rem auto 1rem;
-  }
-
-  .foot {
-    margin: calc(-0.5rem - 0.4em) -0.6em;
-  }
-
-  .foot > * {
-    margin: 0.5rem auto 0.5rem 0;
   }
 
   a.help {
@@ -305,7 +304,7 @@
       ]),
 
       toggle () {
-        this.switchRelease()
+        this.switchRelease(this.release)
         this.$fetch()
       }
     }

--- a/components/download-info.vue
+++ b/components/download-info.vue
@@ -13,6 +13,7 @@
     <template v-if="$fetchState.pending">
       <font-awesome-icon
         :icon="faSpinner"
+        class="loading"
         size="3x"
         spin
       />
@@ -37,13 +38,13 @@
           :class="(!isLts) ? 'selected' : ''"
           @click="toggle"
         >
-          POP!_OS 20.10
+          POP!_OS {{ latestVersion }}
         </div>
         <div
           :class="(isLts) ? 'selected' : ''"
           @click="toggle"
         >
-          POP!_OS 20.04 LTS
+          POP!_OS {{ ltsVersion }} LTS
         </div>
       </div>
 
@@ -118,7 +119,7 @@
   .container {
     border-radius: 3px;
     border: 1px solid transparent;
-    padding: 3rem 1rem;
+    padding: 3rem 1rem 0;
     position: relative;
   }
 
@@ -152,23 +153,41 @@
     background-color: rgba(0, 0, 0, 0.2);
   }
 
+  .loading {
+    display: block;
+    text-align: center;
+    margin: 2rem 4rem 4rem;
+  }
+
   .tab {
-    font-family: var(--font-family-slab);
-    font-size: 1.2rem;
-    font-weight: 700;
-    max-width: 40ch;
-    margin-left: auto;
-    margin-right: auto;
     display: flex;
+    font-family: var(--font-family-slab);
+    font-weight: 700;
+    margin: 0 auto 2rem;
+    max-width: 40ch;
   }
 
   .tab > div {
-    border: 1px solid #574F4A;
+    border: 2px solid #574F4A;
     color: #574F4A;
-    width: 50%;
-    text-align: center;
-    padding: .25em;
     cursor: pointer;
+    padding: 0.25em;
+    text-align: center;
+    width: 50%;
+  }
+
+  .tab > div:first-child {
+    border-bottom-left-radius: 0.25em;
+    border-top-left-radius: 0.25em;
+  }
+
+  .tab > div:not(:first-child) {
+    border-left: none;
+  }
+
+  .tab > div:last-child {
+    border-bottom-right-radius: 0.25em;
+    border-top-right-radius: 0.25em;
   }
 
   .tab > div.selected {
@@ -194,7 +213,7 @@
   }
 
   .disclaimer {
-    margin: 2rem auto 2rem;
+    margin: 1rem auto;
     max-width: 40ch;
     text-align: center;
   }
@@ -269,6 +288,8 @@
         'release',
         'isLts',
         'version',
+        'ltsVersion',
+        'latestVersion',
         'alternativeVersion',
         'channel',
 

--- a/components/index/other-features.vue
+++ b/components/index/other-features.vue
@@ -1,5 +1,12 @@
 <template>
   <section>
+    <light-box v-model="active">
+      <div class="modal">
+        <img
+          :src="require(`~/assets/images/index/${image}-${ (isLight) ? 'light' : 'dark' }.jpg?resize&sizes[]=1920`).src"
+        >
+      </div>
+    </light-box>
     <sys-header-2>Other Features</sys-header-2>
 
     <div :class="[classes, 'block']">
@@ -12,7 +19,10 @@
         </sys-paragraph-1>
       </div>
 
-      <div class="image">
+      <div
+        class="image"
+        @click="toggleModal('other-features-hybrid')"
+      >
         <img
           v-if="isLight"
           v-lazy="require('~/assets/images/index/other-features-hybrid-light.jpg')"
@@ -40,7 +50,10 @@
         </sys-paragraph-1>
       </div>
 
-      <div class="image">
+      <div
+        class="image"
+        @click="toggleModal('other-features-gaming')"
+      >
         <img
           v-if="isLight"
           v-lazy="require('~/assets/images/index/other-features-gaming-light.jpg')"
@@ -68,7 +81,10 @@
         </sys-paragraph-1>
       </div>
 
-      <div class="image">
+      <div
+        class="image"
+        @click="toggleModal('other-features-dnd')"
+      >
         <img
           v-if="isLight"
           v-lazy="require('~/assets/images/index/other-features-dnd-light.jpg')"
@@ -106,7 +122,10 @@
         </label>
       </div>
 
-      <div class="image">
+      <div
+        class="image"
+        @click="toggleModal('other-features-mode')"
+      >
         <img
           v-if="isLight"
           v-lazy="require('~/assets/images/index/other-features-mode-light.jpg')"
@@ -127,6 +146,11 @@
 </template>
 
 <style scoped>
+
+  .modal > img {
+    width: 100%;
+  }
+
   section {
     display: grid;
     grid-gap: 1rem;
@@ -218,6 +242,7 @@
   }
 
   .block .image {
+    cursor: pointer;
     flex: 0 0 auto;
     margin-top: 1rem;
     overflow: hidden;
@@ -295,11 +320,28 @@
 </style>
 
 <script>
+  import LightBox from '~/components/light-box'
   import color from '~/mixins/color'
 
   export default {
+    components: {
+      LightBox
+    },
+
     mixins: [
       color
-    ]
+    ],
+
+    data: () => ({
+      active: false,
+      image: 'other-features-mode'
+    }),
+
+    methods: {
+      toggleModal (image) {
+        this.image = image
+        this.active = true
+      }
+    }
   }
 </script>

--- a/components/index/other-features.vue
+++ b/components/index/other-features.vue
@@ -2,11 +2,10 @@
   <section>
     <light-box v-model="active">
       <div class="modal">
-        <img
-          :src="require(`~/assets/images/index/${image}-${ (isLight) ? 'light' : 'dark' }.jpg?resize&sizes[]=1920`).src"
-        >
+        <img :src="require(`~/assets/images/index/${image}-${ (isLight) ? 'light' : 'dark' }.jpg?resize&sizes[]=1920`).src" />
       </div>
     </light-box>
+
     <sys-header-2>Other Features</sys-header-2>
 
     <div :class="[classes, 'block']">
@@ -146,6 +145,9 @@
 </template>
 
 <style scoped>
+  .modal {
+    width: 80vw;
+  }
 
   .modal > img {
     width: 100%;

--- a/components/index/streamline.vue
+++ b/components/index/streamline.vue
@@ -289,7 +289,7 @@
       grid-template-columns: repeat(3, 1fr);
       grid-template-rows: auto 1fr;
     }
-    .block:nth-child(2) h2 { 
+    .block:nth-child(2) h2 {
       text-align: left;
     }
     .block:nth-child(2) h2,

--- a/components/index/streamline.vue
+++ b/components/index/streamline.vue
@@ -115,8 +115,10 @@
       <sys-subheader-2>Stacking</sys-subheader-2>
 
       <sys-paragraph-1>
-        Stack application windows atop one another like tabs in a web browser. Just remember to switch off of Steam when the boss walks in.
+        Stack application windows atop one another like tabs in a web browser.
+        Just remember to switch off of Steam when the boss walks in.
       </sys-paragraph-1>
+
       <div
         class="video-wrap"
         @click.prevent="toggleVideo('1TSdFWY_U9A')"
@@ -152,7 +154,7 @@
   section {
     display: grid;
     grid-gap: 1rem;
-
+    grid-template-rows: repeat(5, auto);
     margin: 4rem auto;
     max-width: 1280px;
     padding: 0 1rem;
@@ -160,7 +162,7 @@
   }
 
   .copy {
-    /* grid-column: 1 / 2; */
+    grid-column: 1 / 2;
     margin: 0 auto 1rem;
     max-width: 80ch;
   }
@@ -266,9 +268,10 @@
     width: 90vw;
   }
 
-  @media (width >= 120ch) {
+  @media (width >= 900px) {
     section {
-      grid-template-rows: repeat(3, auto);
+      grid-template-columns: repeat(2, auto);
+      grid-template-rows: repeat(2, auto);
     }
 
     .block {
@@ -276,59 +279,41 @@
     }
 
     .copy {
-      grid-area: 1 / 1 / 2 / 4;
+      grid-column: 1 / 3;
     }
   }
 
   @media (width >= 1280px) {
+    section {
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: repeat(3, auto);
+    }
+
+    .copy,
+    .block:nth-child(2) {
+      grid-column: 1 / 4;
+    }
 
     .block:nth-child(2) {
-      grid-area: 2 / 1 / 3 / 4;
       display: grid;
-      grid-gap: 1rem;
-      grid-template-columns: repeat(3, 1fr);
+      grid-gap: 0 1rem;
+      grid-template-columns: auto 45%;
       grid-template-rows: auto 1fr;
     }
-    .block:nth-child(2) h2 {
-      text-align: left;
+
+    .block:nth-child(2) > h2 {
+      grid-area: 1 / 1 / 2 / 2;
+      margin-left: 0;
     }
-    .block:nth-child(2) h2,
-    .block:nth-child(2) p {
-      grid-area: 1 / 1 / 2 / 3;
-      width: 100%;
+
+    .block:nth-child(2) > p {
+      grid-area: 2 / 1 / 3 / 2;
+      align-self: flex-start;
     }
 
     .block:nth-child(2) > .video-wrap {
-      grid-area: 1 / 3 / 2 / 4;
-    }
-
-    .block:nth-child(3) {
-       grid-area: 3 / 1 / 4 / 2;
-    }
-    .block:nth-child(4) {
-        grid-area: 3 / 2 / 4 / 3;
-    }
-    .block:nth-child(5) {
-      grid-area: 3 / 3 / 4 / 4;
-    }
-
-    .block:nth-child(3) > *,
-    .block:nth-child(4) > *,
-    .block:nth-child(5 ) > * {
+      grid-area: 1 / 2 / 3 / 3;
       margin: 0;
-      text-align: left;
-    }
-
-    .block:nth-child(3) h2,
-    .block:nth-child(4) h2,
-    .block:nth-child(5) h2 {
-      text-align: center;
-    }
-
-    .block:nth-child(3) p,
-    .block:nth-child(4) p,
-    .block:nth-child(5) p {
-      margin-top: 1em;
     }
 
     .youtube {

--- a/components/index/streamline.vue
+++ b/components/index/streamline.vue
@@ -111,6 +111,35 @@
       </div>
     </div>
 
+    <div :class="[classes, 'block']">
+      <sys-subheader-2>Stacking</sys-subheader-2>
+
+      <sys-paragraph-1>
+        Stack application windows atop one another like tabs in a web browser. Just remember to switch off of Steam when the boss walks in.
+      </sys-paragraph-1>
+      <div
+        class="video-wrap"
+        @click.prevent="toggleVideo('1TSdFWY_U9A')"
+      >
+        <div class="play-btn">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 494.148 494.148"
+            xml:space="preserve"
+          >
+            <path
+              d="M405.284,201.188L130.804,13.28C118.128,4.596,105.356,0,94.74,0C74.216,0,61.52,16.472,61.52,44.044v406.124c0,27.54,12.68,43.98,33.156,43.98c10.632,0,23.2-4.6,35.904-13.308l274.608-187.904c17.66-12.104,27.44-28.392,27.44-45.884C432.632,229.572,422.964,213.288,405.284,201.188z"
+            />
+          </svg>
+        </div>
+        <img
+          alt="Keyboard navigation video"
+          data-src="https://i.ytimg.com/vi/1TSdFWY_U9A/mqdefault.jpg"
+          class="video"
+        >
+      </div>
+    </div>
+
     <light-box v-model="active">
       <div class="youtube">
         <youtube-responsive :video="video" />
@@ -123,7 +152,7 @@
   section {
     display: grid;
     grid-gap: 1rem;
-    grid-template-rows: repeat(4, auto);
+
     margin: 4rem auto;
     max-width: 1280px;
     padding: 0 1rem;
@@ -131,7 +160,7 @@
   }
 
   .copy {
-    grid-column: 1 / 2;
+    /* grid-column: 1 / 2; */
     margin: 0 auto 1rem;
     max-width: 80ch;
   }
@@ -239,60 +268,67 @@
 
   @media (width >= 120ch) {
     section {
-      grid-template-columns: repeat(2, 1fr);
-      grid-template-rows: auto auto 1fr;
+      grid-template-rows: repeat(3, auto);
     }
 
     .block {
       padding: 2rem;
     }
 
-    .copy,
-    .block:nth-child(2) {
-      grid-column: 1 / 3;
+    .copy {
+      grid-area: 1 / 1 / 2 / 4;
     }
   }
 
   @media (width >= 1280px) {
-    section {
-      grid-template-rows: auto repeat(2, 1fr);
-    }
 
     .block:nth-child(2) {
-      grid-column: 1 / 2;
-      grid-row: 2 / 4;
-    }
-
-    .block:nth-child(3),
-    .block:nth-child(4) {
+      grid-area: 2 / 1 / 3 / 4;
       display: grid;
       grid-gap: 1rem;
-      grid-template-columns: 1fr auto;
+      grid-template-columns: repeat(3, 1fr);
       grid-template-rows: auto 1fr;
+    }
+    .block:nth-child(2) h2 { 
+      text-align: left;
+    }
+    .block:nth-child(2) h2,
+    .block:nth-child(2) p {
+      grid-area: 1 / 1 / 2 / 3;
+      width: 100%;
+    }
+
+    .block:nth-child(2) > .video-wrap {
+      grid-area: 1 / 3 / 2 / 4;
+    }
+
+    .block:nth-child(3) {
+       grid-area: 3 / 1 / 4 / 2;
+    }
+    .block:nth-child(4) {
+        grid-area: 3 / 2 / 4 / 3;
+    }
+    .block:nth-child(5) {
+      grid-area: 3 / 3 / 4 / 4;
     }
 
     .block:nth-child(3) > *,
-    .block:nth-child(4) > * {
+    .block:nth-child(4) > *,
+    .block:nth-child(5 ) > * {
       margin: 0;
       text-align: left;
     }
 
     .block:nth-child(3) h2,
-    .block:nth-child(4) h2 {
-      grid-column: 1 / 2;
-      grid-row: 1 / 2;
+    .block:nth-child(4) h2,
+    .block:nth-child(5) h2 {
+      text-align: center;
     }
 
     .block:nth-child(3) p,
-    .block:nth-child(4) p {
-      grid-column: 2 / 3;
-      grid-row: 1 / 3;
-      width: 20ch;
-    }
-
-    .block:nth-child(3) .video-wrap,
-    .block:nth-child(4) .video-wrap {
-      align-self: center;
+    .block:nth-child(4) p,
+    .block:nth-child(5) p {
+      margin-top: 1em;
     }
 
     .youtube {

--- a/store/download.js
+++ b/store/download.js
@@ -1,6 +1,6 @@
 import { set } from 'vue-analytics'
 
-const LATEST_VERSION = null
+const LATEST_VERSION = '20.10'
 const LTS_VERSION = '20.04'
 
 const NVIDIA_KEYWORDS = [
@@ -68,6 +68,14 @@ export const getters = {
     } else {
       return LTS_VERSION
     }
+  },
+
+  ltsVersion () {
+    return LTS_VERSION
+  },
+
+  latestVersion () {
+    return LATEST_VERSION
   },
 
   alternativeVersion (state) {

--- a/store/download.js
+++ b/store/download.js
@@ -143,10 +143,10 @@ export const mutations = {
   },
 
   switchRelease (state, value) {
-    if (value === 'latest' && LATEST_VERSION != null) {
-      state.channel = 'latest'
-    } else if (value === 'lts' && LTS_VERSION != null) {
-      state.channel = 'lts'
+    if (value === 'lts' && LATEST_VERSION != null) {
+      state.release = 'latest'
+    } else if (value === 'latest' && LTS_VERSION != null) {
+      state.release = 'lts'
     }
   },
 


### PR DESCRIPTION
Updates (from top of page to bottom)

 - Improved download modal with tab-like version selection (latest or LTS)
 - New "Stacking" card in "Streamline" section
 - Updated card layout for "Streamline" section on large screens
 - Screenshots in "Other features" section can be viewed in modal when clicked

Things left to do:

- [x] Fix up the "Auto-tiling" card,
- [x] Add the latest version to `download.js` to enable tab on download modal. 