### PR TITLE
Remove event emit functions

### DIFF
--- a/store/payment.js
+++ b/store/payment.js
@@ -344,21 +344,15 @@ export const actions = {
       commit('setSubscription', body)
       commit('setSubscribing', false)
 
-      event('payment', 'subscription', 'success')
-
       return true
     } else if (res.status === 402) {
       commit('setError', 'Payment failed')
       commit('setSubscribing', false)
 
-      event('payment', 'subscription', 'failure')
-
       return false
     } else {
       commit('setError', 'Error creating subscription')
       commit('setSubscribing', false)
-
-      event('payment', 'subscription', 'error')
 
       return false
     }


### PR DESCRIPTION
We removed google analytics, which made the subscription function run, set subscribing to false (making the subscribe button clickable again), and then the event function undefined and throw an error. This resulted in people being able to subscribe multiple times.