### PR TITLE
Rename Pop!_community link to Pop!_Chat

### DIFF
--- a/components/index/footnotes.vue
+++ b/components/index/footnotes.vue
@@ -19,7 +19,7 @@
         target="_blank"
       >
         <font-awesome-icon :icon="faMattermost" />
-        Pop!_community
+        Pop!_Chat
       </a>
 
       <a


### PR DESCRIPTION
This is to match the styling we have in the Pop!_Chat, and how we usually refer to it.