### PR TITLE
Replace h5 tag by span to improve accessibility

### DIFF
--- a/components/index/testimonials.vue
+++ b/components/index/testimonials.vue
@@ -28,7 +28,7 @@
         />
 
         <p>{{ current.content }}</p>
-        <h5>{{ current.name }}</h5>
+        <span class="name">{{ current.name }}</span>
 
         <img
           class="avatar"
@@ -149,6 +149,13 @@
     object-position: center;
     user-select: none;
     width: 8rem;
+  }
+
+  .name {
+    font-size: 0.83em;
+    margin-block-start: 1.67em;
+    margin-block-end: 1.67em;
+    font-weight: bold;
   }
 
   @media (width >= 600px) {


### PR DESCRIPTION
Small change to improve the accessibility score on [google lighthouse](https://developer.chrome.com/docs/lighthouse/overview/)

The `<h5>` tag was replaced by `<span>` on testimonials component.

#### Before
![image](https://github.com/pop-os/website/assets/6011542/c3bc4f7b-0513-4bbe-bb32-35fa7544539e)

#### With this current change
![image](https://github.com/pop-os/website/assets/6011542/0d418f50-1f0b-4547-ba28-e016bd27ec2a)
